### PR TITLE
fix: Hot Reload Fails, DOM adds an additional iframe

### DIFF
--- a/packages/lb-demo/package.json
+++ b/packages/lb-demo/package.json
@@ -15,7 +15,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
-    "web-vitals": "^1.0.2"
+    "web-vitals": "^1.0.2",
+    "react-error-overlay": "6.0.9"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
There is the solution from  https://github.com/facebook/create-react-app/issues/11880
```
- Change the react-script version to 4.0.3 inside package.json.
- Add this to package.json below the dependencies
- "resolutions": { "react-error-overlay": "6.0.9" },
- Install react-error-overlay v6.0.9 inside your devDependencies.
- Remove your node_modules and package-lock.json.
- Do npm install and check that works.
```