### PR TITLE
Feat speed of page turn

### DIFF
--- a/packages/lb-annotation/src/core/pointCloud/index.ts
+++ b/packages/lb-annotation/src/core/pointCloud/index.ts
@@ -75,7 +75,7 @@ export interface IPointCloudDelegate extends IEventBus {
 }
 
 const DEFAULT_DISTANCE = 30;
-const highlightWorker = new HighlightWorker({ type: 'module' });
+let highlightWorker = new HighlightWorker({ type: 'module' });
 
 export class PointCloud extends EventListener {
   public renderer: THREE.WebGLRenderer;
@@ -1062,8 +1062,14 @@ export class PointCloud extends EventListener {
   public async handleWebworker(params: any) {
     return new Promise((resolve, reject) => {
       if (this.workerLoading) {
-        reject(new Error('workerLoading'));
-        return;
+        /**
+         * reject(new Error('workerLoading'));
+         * return;
+         * Previous logic: If a web worker is triggered again while working, an error is thrown.
+         * Current logic: If a web worker is triggered again while working, the previous worker is terminated, and a new one is created.
+         */
+        highlightWorker.terminate();
+        highlightWorker = new HighlightWorker({ type: 'module' });
       }
       this.workerLoading = true;
       highlightWorker.postMessage(params);

--- a/packages/lb-components/src/components/pointCloudView/PointCloudListener.tsx
+++ b/packages/lb-components/src/components/pointCloudView/PointCloudListener.tsx
@@ -82,7 +82,7 @@ const PointCloudListener: React.FC<IProps> = ({
   };
 
   const keydownEvents = (lowerCaseKey: string, e: KeyboardEvent) => {
-    const { topViewInstance, mainViewInstance } = ptCtx;
+    const { topViewInstance, mainViewInstance, rectRotateSensitivity } = ptCtx;
     if (!topViewInstance) {
       return;
     }
@@ -92,13 +92,13 @@ const PointCloudListener: React.FC<IProps> = ({
     switch (lowerCaseKey) {
       case 'q': {
         // Q - anticlockwise
-        updateRotate(ptCtx.rectRotateSensitivity);
+        updateRotate(rectRotateSensitivity);
         break;
       }
 
       case 'e':
         // E - clockwise
-        updateRotate(-Number(ptCtx.rectRotateSensitivity));
+        updateRotate(-Number(rectRotateSensitivity));
         break;
 
       case 'g':

--- a/packages/lb-components/src/components/pointCloudView/PointCloudTopView.tsx
+++ b/packages/lb-components/src/components/pointCloudView/PointCloudTopView.tsx
@@ -43,6 +43,7 @@ import { DrawLayerSlot } from '@/types/main';
 import ToolUtils from '@/utils/ToolUtils';
 import _ from 'lodash';
 import PointCloudSizeSlider from './components/PointCloudSizeSlider';
+import PointCloudDynamicHighlightSwitch from './components/PointCloudDynamicHighlightSwitch';
 import { useHistory } from './hooks/useHistory';
 import TitleButton from './components/TitleButton';
 
@@ -87,23 +88,40 @@ const TopViewToolbar = ({ currentData }: IAnnotationStateProps) => {
   const { updateRotate } = useRotate({ currentData });
   const { updateRotateEdge } = useRotateEdge({ currentData });
   const ptCtx = React.useContext(PointCloudContext);
-  const { topViewInstance } = ptCtx;
+  const {
+    topViewInstance,
+    rectRotateSensitivity,
+    isDynamicHighlightPointCloudEnabled,
+    setIsDynamicHighlightPointCloudEnabled,
+    isDynamicHighlightLoading,
+  } = ptCtx;
 
   const currentToolName = ptCtx?.topViewInstance?.toolScheduler?.getCurrentToolName();
 
   const clockwiseRotate = () => {
-    updateRotate(-Number(ptCtx.rectRotateSensitivity));
+    updateRotate(-Number(rectRotateSensitivity));
   };
   const anticlockwiseRotate = () => {
-    updateRotate(ptCtx.rectRotateSensitivity);
+    updateRotate(rectRotateSensitivity);
   };
 
   const reverseRotate = () => {
     updateRotateEdge(-90);
   };
 
+  const handleHighlightSwitch = (enable: boolean) => {
+    setIsDynamicHighlightPointCloudEnabled(enable);
+  };
+
   return (
     <>
+      <PointCloudDynamicHighlightSwitch
+        onChange={(enable: boolean) => {
+          handleHighlightSwitch(enable);
+        }}
+        defaultChecked={isDynamicHighlightPointCloudEnabled}
+        loading={isDynamicHighlightLoading}
+      />
       <PointCloudSizeSlider
         onChange={(v: number) => {
           topViewInstance?.pointCloudInstance?.updatePointSize({ customSize: v });

--- a/packages/lb-components/src/components/pointCloudView/components/PointCloudDynamicHighlightSwitch/index.tsx
+++ b/packages/lb-components/src/components/pointCloudView/components/PointCloudDynamicHighlightSwitch/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { getClassName } from '@/utils/dom';
+import { Switch } from 'antd';
+import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+
+interface IProps {
+  onChange: (checked: boolean) => void;
+  defaultChecked: boolean;
+  loading: boolean;
+}
+
+const PointCloudDynamicHighlightSwitch = ({ onChange, defaultChecked, loading }: IProps) => {
+  const { t } = useTranslation();
+  return (
+    <span className={getClassName('point-cloud-container', 'switch-container')}>
+      <span className={getClassName('point-cloud-container', 'switch-container', 'label')}>
+      {t('HighlightedInsideRect')}
+      </span>
+      <span className={getClassName('point-cloud-container', 'switch-container', 'switch')}>
+        <Switch
+          onChange={onChange}
+          checkedChildren={<CheckOutlined />}
+          unCheckedChildren={<CloseOutlined />}
+          defaultChecked={defaultChecked}
+          loading={loading}
+        />
+      </span>
+    </span>
+  );
+};
+
+export default PointCloudDynamicHighlightSwitch;

--- a/packages/lb-components/src/components/pointCloudView/hooks/usePointCloudViews.ts
+++ b/packages/lb-components/src/components/pointCloudView/hooks/usePointCloudViews.ts
@@ -1338,8 +1338,10 @@ export const usePointCloudViews = () => {
       /**
        * Use [] to replace the default highlight2DDataList.
        * Need to await syncAllViewPointCloudColor before setLoading(false).
+       * @Hexing update 2024-06-14
+       * remote await to avoid blocking the page loading when turning pages.
        */
-      await ptCtx.syncAllViewPointCloudColor(boxParamsList, []);
+      ptCtx.syncAllViewPointCloudColor(boxParamsList, []);
     }
 
     initHistory({

--- a/packages/lb-components/src/index.scss
+++ b/packages/lb-components/src/index.scss
@@ -1610,6 +1610,15 @@ $headerHeight: 40px;
       }
     }
 
+    &__switch-container {
+      &__label {
+        margin-right: 8px;
+      }
+      &__switch {
+        margin-right: 16px;
+      }
+    }
+
     &__header-title-box {
       position: absolute;
       top: 16px;

--- a/packages/lb-components/src/store/annotatedBox/index.tsx
+++ b/packages/lb-components/src/store/annotatedBox/index.tsx
@@ -17,8 +17,6 @@ interface Store {
   setHighlightIDs: (highlightIDs: number[]) => void;
   selectedIDs: string[];
   setSelectedIDs: (selectedIDs: string[]) => void;
-  rectRotateSensitivity: number;
-  setRectRotateSensitivity: (sensitivity: number) => void;
   setPtCtx: (ptCtx: IPointCloudContext) => void;
 }
 
@@ -33,9 +31,6 @@ const useAnnotatedBoxStore = create<Store>((set) => ({
     set((state) => {
       return { selectedIDs };
     }),
-  rectRotateSensitivity: 2,
-  setRectRotateSensitivity: (sensitivity) =>
-    set((state) => ({ rectRotateSensitivity: sensitivity })),
   setPtCtx: (ptCtx) => set((state) => ({ ptCtx })),
 }));
 

--- a/packages/lb-utils/src/i18n/resources.json
+++ b/packages/lb-utils/src/i18n/resources.json
@@ -362,7 +362,8 @@
     "ProjectionFrameCannotBeDeleted": "Projection frame cannot be deleted",
     "FailedToCopyResults": "Failed to copy results",
     "PartialResultsReplicationFailure": "Partial results replication failure",
-    "RotationAngleSensitivity": "Rotation angle sensitivity"
+    "RotationAngleSensitivity": "Rotation angle sensitivity",
+    "HighlightedInsideRect": "Highlighted inside rect"
   },
   "cn": {
     "TextInput": "文本输入",
@@ -727,6 +728,7 @@
     "ProjectionFrameCannotBeDeleted": "投射框无法删除",
     "FailedToCopyResults": "复制结果失败",
     "PartialResultsReplicationFailure": "部分结果复制失败",
-    "RotationAngleSensitivity": "旋转微调角度"
+    "RotationAngleSensitivity": "旋转微调角度",
+    "HighlightedInsideRect": "高亮框中"
   }
 }


### PR DESCRIPTION
Impact scope: Point cloud annotation
1. Modified the pagination logic, changing the highlight rendering to not block page turning.
2. Changed the logic of concurrent calls to the highlight rendering webworker from "reject current, maintain previous" to "terminate previous, execute current".
3. Added a switch inside the highlight box, supporting loading during rendering and immediate rendering upon switch state change.
